### PR TITLE
UITextFieldのメソッドチェーン.placeholderが効かない

### DIFF
--- a/Sources/DeclarativeUIKit/ViewExtension/UITextField+.swift
+++ b/Sources/DeclarativeUIKit/ViewExtension/UITextField+.swift
@@ -22,12 +22,7 @@ private extension UITextField {
     }
     
     @discardableResult
-    func setupPlaceholder(attrText: NSAttributedString?) -> Self {
-        guard let attrText = attrText else {
-            self.placeholder = nil
-            self.attributedPlaceholder = nil
-            return self
-        }
+    func setupPlaceholder(attrText: NSAttributedString) -> Self {
         self.attributedPlaceholder = attrText
         return self
     }

--- a/Sources/DeclarativeUIKit/ViewExtension/UITextField+.swift
+++ b/Sources/DeclarativeUIKit/ViewExtension/UITextField+.swift
@@ -106,9 +106,6 @@ public extension UITextField {
 
     @discardableResult
     func placeholder(_ placeholder: String?) -> Self {
-        guard let text = text else {
-            return self.setupPlaceholder(attrText: nil)
-        }
         return self.setupPlaceholder(attrText: NSAttributedString(string: text))
     }
 

--- a/Sources/DeclarativeUIKit/ViewExtension/UITextField+.swift
+++ b/Sources/DeclarativeUIKit/ViewExtension/UITextField+.swift
@@ -22,7 +22,12 @@ private extension UITextField {
     }
     
     @discardableResult
-    func setupPlaceholder(attrText: NSAttributedString) -> Self {
+    func setupPlaceholder(attrText: NSAttributedString?) -> Self {
+        guard let attrText = attrText else {
+            self.placeholder = nil
+            self.attributedPlaceholder = nil
+            return self
+        }
         self.attributedPlaceholder = attrText
         return self
     }
@@ -101,7 +106,10 @@ public extension UITextField {
 
     @discardableResult
     func placeholder(_ placeholder: String?) -> Self {
-        return self.setupPlaceholder(attrText: NSAttributedString(string: text))
+        guard let placeholder = placeholder else {
+            return self.setupPlaceholder(attrText: nil)
+        }
+        return self.setupPlaceholder(attrText: NSAttributedString(string: placeholder))
     }
 
     @discardableResult


### PR DESCRIPTION
placeholderの性質上、textが設定されていない場合にこそplaceholderを表示したい=nilだと表示されず困る。
そもそも、textがある時は、UIKit側で非表示になるはずなので、nilを通せるようにする必要がないと思いました。
メモリの節約？になるかもしれないですが、パフォーマンスには全く影響しないはず。